### PR TITLE
Added Support for Ad Astra Space Suit Oxygen

### DIFF
--- a/src/generated/resources/data/beyond_oxygen/tags/items/breathables.json
+++ b/src/generated/resources/data/beyond_oxygen/tags/items/breathables.json
@@ -8,6 +8,14 @@
     {
       "id": "ad_astra:large_gas_tank",
       "required": false
+    },
+    {
+      "id": "ad_astra:space_suit",
+      "required": false
+    },
+    {
+      "id": "ad_astra:netherite_space_suit",
+      "required": false
     }
   ]
 }

--- a/src/main/java/com/sierravanguard/beyond_oxygen/data/BOItemTagsProvider.java
+++ b/src/main/java/com/sierravanguard/beyond_oxygen/data/BOItemTagsProvider.java
@@ -87,7 +87,9 @@ public class BOItemTagsProvider extends TagsProvider<Item> {
         this.tag(BOItemTags.BREATHABLES)
                 .add(BOItems.OXYGEN_TANK.getKey())
                 .addOptional(ModItems.GAS_TANK.getId())
-                .addOptional(ModItems.LARGE_GAS_TANK.getId());
+                .addOptional(ModItems.LARGE_GAS_TANK.getId())
+                .addOptional(ModItems.SPACE_SUIT.getId())
+                .addOptional(ModItems.NETHERITE_SPACE_SUIT.getId());
 
         this.tag(BOItemTags.STEEL_INGOT)
                 .addOptionalTag(BOItemTags.FORGE_STEEL_INGOT);

--- a/src/main/java/com/sierravanguard/beyond_oxygen/registry/BOOxygenSources.java
+++ b/src/main/java/com/sierravanguard/beyond_oxygen/registry/BOOxygenSources.java
@@ -28,7 +28,8 @@ public class BOOxygenSources {
     public static final int DEFAULT_PRIORITY_PLAYER_INVENTORY = 2000;
     public static final int DEFAULT_PRIORITY_HELD_ITEMS = 3000;
 
-    public static final ResourceKey<Registry<OxygenSource<?>>> REGISTRY_KEY = ResourceKey.createRegistryKey(new ResourceLocation(BeyondOxygen.MODID, "oxygen_sources"));
+    @SuppressWarnings("removal")
+	public static final ResourceKey<Registry<OxygenSource<?>>> REGISTRY_KEY = ResourceKey.createRegistryKey(new ResourceLocation(BeyondOxygen.MODID, "oxygen_sources"));
     private static DeferredRegister<OxygenSource<?>> registry = DeferredRegister.create(REGISTRY_KEY, BeyondOxygen.MODID);
     public static final Supplier<IForgeRegistry<OxygenSource<?>>> REGISTRY = registry.makeRegistry(() -> RegistryBuilder.of(REGISTRY_KEY.location()));
 
@@ -37,7 +38,7 @@ public class BOOxygenSources {
             entity -> Arrays.stream(EquipmentSlot.values())
                     .filter(EquipmentSlot::isArmor)
                     .map(entity::getItemBySlot)
-                    .filter(stack -> stack.getItem() instanceof OxygenStorageArmorItem)));
+                    .filter(stack -> stack.getItem() instanceof OxygenStorageArmorItem || stack.is(BOItemTags.BREATHABLES))));
     public static final RegistryObject<OxygenSource<ItemStack>> HELD_ITEMS = registry.register("held_items", () -> OxygenSource.forItems(
             DEFAULT_PRIORITY_HELD_ITEMS,
             entity -> Arrays.stream(EquipmentSlot.values())

--- a/src/main/java/com/sierravanguard/beyond_oxygen/utils/OxygenManager.java
+++ b/src/main/java/com/sierravanguard/beyond_oxygen/utils/OxygenManager.java
@@ -2,7 +2,6 @@ package com.sierravanguard.beyond_oxygen.utils;
 
 import com.sierravanguard.beyond_oxygen.BOConfig;
 import com.sierravanguard.beyond_oxygen.BOServerConfig;
-import com.sierravanguard.beyond_oxygen.registry.BODimensions;
 import com.sierravanguard.beyond_oxygen.registry.BOEffects;
 import com.sierravanguard.beyond_oxygen.registry.BOFluids;
 import com.sierravanguard.beyond_oxygen.registry.BOOxygenSources;
@@ -13,7 +12,6 @@ import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraft.server.level.ServerLevel;
 
 import java.util.*;
 import java.util.stream.Stream;
@@ -38,7 +36,6 @@ public class OxygenManager {
     }
     
     public static void consumeOxygen(LivingEntity entity) {
-        if(OxygenHelper.isInBreathableEnvironment(entity)) return;
         if (!SpaceSuitHandler.isWearingFullSuit(entity)) return;
         int mbToDrain = 1;
         IntReference needs = new IntReference(mbToDrain);

--- a/src/main/java/com/sierravanguard/beyond_oxygen/utils/OxygenManager.java
+++ b/src/main/java/com/sierravanguard/beyond_oxygen/utils/OxygenManager.java
@@ -2,6 +2,7 @@ package com.sierravanguard.beyond_oxygen.utils;
 
 import com.sierravanguard.beyond_oxygen.BOConfig;
 import com.sierravanguard.beyond_oxygen.BOServerConfig;
+import com.sierravanguard.beyond_oxygen.registry.BODimensions;
 import com.sierravanguard.beyond_oxygen.registry.BOEffects;
 import com.sierravanguard.beyond_oxygen.registry.BOFluids;
 import com.sierravanguard.beyond_oxygen.registry.BOOxygenSources;
@@ -12,6 +13,7 @@ import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraft.server.level.ServerLevel;
 
 import java.util.*;
 import java.util.stream.Stream;
@@ -36,6 +38,7 @@ public class OxygenManager {
     }
     
     public static void consumeOxygen(LivingEntity entity) {
+        if(OxygenHelper.isInBreathableEnvironment(entity)) return;
         if (!SpaceSuitHandler.isWearingFullSuit(entity)) return;
         int mbToDrain = 1;
         IntReference needs = new IntReference(mbToDrain);


### PR DESCRIPTION
Ad Astra spacesuit armour can now be drained of its oxygen like the spacesuit included in beyond oxygen by default